### PR TITLE
refactor entity chore

### DIFF
--- a/src/it/scala/contact/ContactServerSpec.scala
+++ b/src/it/scala/contact/ContactServerSpec.scala
@@ -1,17 +1,22 @@
 package contact
+
 import cats.implicits._
 import cats.effect.IO
+
 import io.circe._
 import io.circe.literal._
 import io.circe.optics.JsonPath._
+
+import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.blaze._
 import org.http4s.server.blaze._
 import org.http4s.server.{Server => Http4sServer}
-import org.http4s._
-import org.scalatest._
-import fpa._
 import org.http4s.server.middleware.Logger
+
+import org.scalatest._
+
+import fpa._
 
 class ContactServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 

--- a/src/main/scala/contact/model.scala
+++ b/src/main/scala/contact/model.scala
@@ -43,20 +43,13 @@ object Contact {
   implicit val contactDecoder: Decoder[Contact] =
     deriveDecoder[Contact]
 
-  implicit def contactEntity[F[_] : Sync]: Entity[F, Contact] =
-    new Entity[F, Contact] {
-
-      val F = implicitly[Sync[F]]
+  implicit def contactEntity[F[_]](implicit F: Sync[F]): HasIdentity[F, Contact] =
+    new HasIdentity[F, Contact] {
 
       def id(contact: Contact): F[Option[Identity]] =
         F.delay(contact.id)
 
       def withId(contact: Contact)(id: Identity): F[Contact] =
         F.delay(contact.copy(id = Some(id)))
-
-      def withGeneratedId(contact: Contact): F[Contact] =
-        withId(contact)(Identity.generate())
-
     }
-
 }

--- a/src/main/scala/fpa/Repository.scala
+++ b/src/main/scala/fpa/Repository.scala
@@ -7,7 +7,7 @@ trait StreamingRepository[F[_], A] {
   def stream: Stream[F, A]
 }
 
-abstract class CrudRepository[F[_], A : Entity[F, ?]] {
+abstract class CrudRepository[F[_], A : HasIdentity[F, ?]](name: String) {
   type Result[A] = Either[RepositoryError, A]
   def create(a: A): F[Result[Unit]]
   def read(id: Identity): F[Result[A]]
@@ -15,8 +15,9 @@ abstract class CrudRepository[F[_], A : Entity[F, ?]] {
   def delete(id: Identity): F[Result[Unit]]
 }
 
-abstract class Repository[F[_], A : Entity[F, ?]](val name: String)
-  extends CrudRepository[F, A] with StreamingRepository[F, A]
+abstract class Repository[F[_], A : HasIdentity[F, ?]](val name: String)
+  extends CrudRepository[F, A](name)
+  with StreamingRepository[F, A]
 
 package object repository {
 

--- a/src/main/scala/fpa/Service.scala
+++ b/src/main/scala/fpa/Service.scala
@@ -19,14 +19,14 @@ import service._
 
 import scala.util.Try
 
-class Service[F[_] : Effect, A : Decoder : Encoder : Entity[F, ?]](
+class Service[F[_] : Effect, A : Decoder : Encoder : HasIdentity[F, ?]](
   segment: String, repository: Repository[F, A]
 ) extends Http4sDsl[F] {
 
   type EndPoint = Kleisli[F, Request[F], Response[F]]
   val  EndPoint = Kleisli
 
-  val E = implicitly[Entity[F, A]]
+  val E = implicitly[HasIdentity[F, A]]
 
   def http = HttpService[F] {
     case req @ POST    -> Root / `segment`                    =>  create(req)


### PR DESCRIPTION
Prior rollback to origin, we leave the branch re-entity as an example, but merge to master non-the-less to maintain history for the future.