### PR TITLE
fixing config property name

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -12,5 +12,5 @@ database {
 
 logging {
   log-headers: true
-  log-Body: true
+  log-body: true
 }


### PR DESCRIPTION
i think the property name should be log-body instead of log-Body, because the server did not start otherwise